### PR TITLE
Fix EventBus memory leak

### DIFF
--- a/ponysdk/src/main/java/com/ponysdk/core/server/application/UIContext.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/server/application/UIContext.java
@@ -61,6 +61,7 @@ import com.ponysdk.core.ui.basic.PWindow;
 import com.ponysdk.core.ui.eventbus.BroadcastEventHandler;
 import com.ponysdk.core.ui.eventbus.Event;
 import com.ponysdk.core.ui.eventbus.EventHandler;
+import com.ponysdk.core.ui.eventbus.EventSource;
 import com.ponysdk.core.ui.eventbus.HandlerRegistration;
 import com.ponysdk.core.ui.eventbus.StreamHandler;
 import com.ponysdk.core.ui.statistic.TerminalDataReceiver;
@@ -194,11 +195,11 @@ public class UIContext {
     }
 
     public void executeFireEvent(final Event<? extends EventHandler> event) {
-        execute(() -> fireEvent0(event));
+    	execute(() -> fireEvent0(event));
     }
 
     private void fireEvent0(final Event<? extends EventHandler> event) {
-        rootEventBus.fireEvent(event);
+    	rootEventBus.fireEvent(event);
     }
 
     /**
@@ -213,52 +214,26 @@ public class UIContext {
     }
 
     /**
-     * Adds {@link EventHandler} to the {@link com.ponysdk.core.ui.eventbus.EventBus} with a specific source
-     * Use {@link #fireEventFromSource(Event, Object)} to stimulate this event handler
-     *
-     * @param type the event type
-     * @param source the source
-     * @param handler the event handler
-     * @return the {@link HandlerRegistration} in order to remove the {@link EventHandler}
-     * @see #fireEventFromSource(Event, Object)
-     */
-    public static HandlerRegistration addHandlerToSource(final Event.Type type, final Object source, final EventHandler handler) {
-        return get().rootEventBus.addHandlerToSource(type, source, handler);
-    }
-
-    /**
      * Fires an {@link Event} on the {@link com.ponysdk.core.ui.eventbus.EventBus} with a specific source
      * Only {@link EventHandler}s added before fires event will be stimulated
      *
      * @param event the fired event
      * @param source the source
-     * @see #addHandlerToSource(com.ponysdk.core.ui.eventbus.Event.Type, Object, EventHandler)
      */
-    public static void fireEventFromSource(final Event<? extends EventHandler> event, final Object source) {
+    public static void fireEventFromSource(final Event<? extends EventHandler> event, final EventSource source) {
         get().rootEventBus.fireEventFromSource(event, source);
-    }
-
-    /**
-     * Removes handler from the {@link com.ponysdk.core.ui.eventbus.EventBus} with a specific source
-     *
-     * @param type the event type
-     * @param source the source
-     * @param handler the event handler
-     * @see #addHandlerToSource(com.ponysdk.core.ui.eventbus.Event.Type, Object, EventHandler)
-     */
-    public static void removeHandlerFromSource(final Event.Type type, final Object source, final EventHandler handler) {
-        get().rootEventBus.removeHandlerFromSource(type, source, handler);
     }
 
     /**
      * Adds a {@link BroadcastEventHandler} to the {@link com.ponysdk.core.ui.eventbus.EventBus} that receive all the
      * events
-     * All call to {@link #fireEvent(Event)} or {@link #fireEventFromSource(Event, Object)} will stimulate this event
+     * All call to {@link #fireEvent(Event)} or {@link #fireEventFromSource(Event, EventSource)} will stimulate this
+     * event
      * handler
      *
      * @param handler the broadcast event handler
      * @see #fireEvent(Event)
-     * @see #fireEventFromSource(Event, Object)
+     * @see #fireEventFromSource(Event, EventSource)
      */
     public static void addHandler(final BroadcastEventHandler handler) {
         get().rootEventBus.addHandler(handler);

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/activity/AbstractActivity.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/activity/AbstractActivity.java
@@ -95,28 +95,8 @@ public abstract class AbstractActivity<T extends IsPWidget> implements Activity 
         UIContext.removeHandler(type, handler);
     }
 
-    public HandlerRegistration addHandlerToSource(final Event.Type type, final Object source, final EventHandler handler) {
-        return UIContext.addHandlerToSource(type, source, handler);
-    }
-
-    public void removeHandlerFromSource(final Event.Type type, final Object source, final EventHandler handler) {
-        UIContext.removeHandlerFromSource(type, source, handler);
-    }
-
-    public HandlerRegistration addHandlerToSource(final Event.Type type, final Object source) {
-        return addHandlerToSource(type, source, (EventHandler) this);
-    }
-
-    public void removeHandlerFromSource(final Event.Type type, final Object source) {
-        removeHandlerFromSource(type, source, (EventHandler) this);
-    }
-
     public void fireEvent(final Event<? extends EventHandler> event) {
         UIContext.fireEvent(event);
-    }
-
-    public void fireEventFromSource(final Event<? extends EventHandler> event, final Object source) {
-        UIContext.fireEventFromSource(event, source);
     }
 
     public void addHandler(final BroadcastEventHandler handler) {

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/eventbus/EventSource.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/eventbus/EventSource.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2019 PonySDK
+ *  Owners:
+ *  Luciano Broussal  <luciano.broussal AT gmail.com>
+ *	Mathieu Barbier   <mathieu.barbier AT gmail.com>
+ *	Nicolas Ciaravola <nicolas.ciaravola.pro AT gmail.com>
+ *
+ *  WebSite:
+ *  http://code.google.com/p/pony-sdk/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.ponysdk.core.ui.eventbus;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class EventSource {
+
+    private final Map<Event.Type, Set<EventHandler>> handlers;
+
+    public EventSource() {
+        this.handlers = newHandlersMap();
+    }
+
+    protected Set<EventHandler> newHandlersSet() {
+        return new HashSet<>();
+    }
+
+    protected Map<Event.Type, Set<EventHandler>> newHandlersMap() {
+        return new HashMap<>();
+    }
+
+    public HandlerRegistration addHandler(final Event.Type type, final EventHandler handler) {
+        if (type == null) throw new NullPointerException("Cannot add a handler with a null type");
+        if (handler == null) throw new NullPointerException("Cannot add a null handler");
+        handlers.computeIfAbsent(type, t -> newHandlersSet()).add(handler);
+        return () -> removeHandler(type, handler);
+    }
+
+    public boolean removeHandler(final Event.Type type, final EventHandler handler) {
+        final Set<EventHandler> typeHandlers = handlers.get(type);
+        if (typeHandlers == null) return false;
+        return typeHandlers.remove(handler);
+    }
+
+    public Collection<EventHandler> getEventHandlers(final Event.Type eventType) {
+        return handlers.getOrDefault(eventType, Collections.emptySet());
+    }
+}

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/eventbus/TinyEventSource.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/eventbus/TinyEventSource.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019 PonySDK
+ *  Owners:
+ *  Luciano Broussal  <luciano.broussal AT gmail.com>
+ *	Mathieu Barbier   <mathieu.barbier AT gmail.com>
+ *	Nicolas Ciaravola <nicolas.ciaravola.pro AT gmail.com>
+ *
+ *  WebSite:
+ *  http://code.google.com/p/pony-sdk/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.ponysdk.core.ui.eventbus;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import com.ponysdk.core.ui.eventbus.Event.Type;
+import com.ponysdk.core.util.SetUtils;
+
+public class TinyEventSource extends EventSource {
+
+    @Override
+    protected Map<Type, Set<EventHandler>> newHandlersMap() {
+        return new HashMap<>(4);
+    }
+
+    @Override
+    protected Set<EventHandler> newHandlersSet() {
+        return SetUtils.newArraySet(1);
+    }
+
+}

--- a/ponysdk/src/test/java/com/ponysdk/core/ui/eventbus/EventBusTest.java
+++ b/ponysdk/src/test/java/com/ponysdk/core/ui/eventbus/EventBusTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2019 PonySDK
+ *  Owners:
+ *  Luciano Broussal  <luciano.broussal AT gmail.com>
+ *	Mathieu Barbier   <mathieu.barbier AT gmail.com>
+ *	Nicolas Ciaravola <nicolas.ciaravola.pro AT gmail.com>
+ *
+ *  WebSite:
+ *  http://code.google.com/p/pony-sdk/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.ponysdk.core.ui.eventbus;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ponysdk.core.ui.basic.PSuite;
+
+public class EventBusTest extends PSuite {
+
+    private static final Event.Type CLICK_EVENT_TYPE = new Event.Type();
+    private static final Event.Type HOVER_EVENT_TYPE = new Event.Type();
+
+    @Test
+    public void testGlobalHandler() {
+        final EventBus eventBus = new EventBus();
+        final TestEventHandler clickEventHandler = new TestEventHandler();
+        eventBus.addHandler(CLICK_EVENT_TYPE, clickEventHandler);
+        final Event<TestEventHandler> hoverEvent = new HoverTestEvent(null);
+        eventBus.fireEvent(hoverEvent);
+        assertFalse("Click handler should NOT have been invoked", clickEventHandler.invoked);
+        final Event<TestEventHandler> clickEvent = new ClickTestEvent(null);
+        eventBus.fireEvent(clickEvent);
+        assertTrue("Click handler should have been invoked", clickEventHandler.invoked);
+        eventBus.removeHandler(CLICK_EVENT_TYPE, clickEventHandler);
+        clickEventHandler.invoked = false;
+        eventBus.fireEvent(clickEvent);
+        assertFalse("Click handler should NOT have been invoked", clickEventHandler.invoked);
+    }
+
+    @Test
+    public void testSourceHandler() {
+        final EventBus eventBus = new EventBus();
+        final EventSource eventSource = new EventSource();
+        final TestEventHandler clickEventHandler = new TestEventHandler();
+        eventSource.addHandler(CLICK_EVENT_TYPE, clickEventHandler);
+        final Event<TestEventHandler> hoverEvent = new HoverTestEvent(eventSource);
+        eventBus.fireEventFromSource(hoverEvent, eventSource);
+        assertFalse("Click handler should NOT have been invoked", clickEventHandler.invoked);
+        final Event<TestEventHandler> clickEvent = new ClickTestEvent(eventSource);
+        eventBus.fireEventFromSource(clickEvent, eventSource);
+        assertTrue("Click handler should have been invoked", clickEventHandler.invoked);
+        eventSource.removeHandler(CLICK_EVENT_TYPE, clickEventHandler);
+        clickEventHandler.invoked = false;
+        eventBus.fireEventFromSource(clickEvent, eventSource);
+        assertFalse("Click handler should NOT have been invoked", clickEventHandler.invoked);
+    }
+
+    @Test
+    public void testBroadcastHandler() {
+        final EventBus eventBus = new EventBus();
+        final TestBroadcastHandler broadcastHandler = new TestBroadcastHandler();
+        eventBus.addHandler(broadcastHandler);
+        assertFalse("Broadcast handler should NOT have been invoked", broadcastHandler.invoked);
+        final Event<TestEventHandler> clickEvent = new ClickTestEvent(null);
+        eventBus.fireEvent(clickEvent);
+        assertTrue("Broadcast handler should have been invoked", broadcastHandler.invoked);
+        eventBus.removeHandler(broadcastHandler);
+        broadcastHandler.invoked = false;
+        eventBus.fireEvent(clickEvent);
+        assertFalse("Broadcast handler should NOT have been invoked", broadcastHandler.invoked);
+    }
+
+    @Test
+    public void testSingleHandlerPerEventType() {
+        final EventBus eventBus = new EventBus();
+        final EventSource eventSource = new EventSource();
+        final TestEventHandler clickEventHandler = new TestEventHandler();
+        final TestEventHandler hoverEventHandler = new TestEventHandler();
+        eventBus.addHandler(CLICK_EVENT_TYPE, clickEventHandler);
+        eventBus.addHandler(HOVER_EVENT_TYPE, hoverEventHandler);
+        final Event<TestEventHandler> clickEvent = new ClickTestEvent(eventSource);
+        assertFalse("Click handler should NOT have been invoked", clickEventHandler.invoked);
+        assertFalse("Hover handler should NOT have been invoked", hoverEventHandler.invoked);
+        eventBus.fireEventFromSource(clickEvent, eventSource);
+        assertTrue("Click handler should have been invoked", clickEventHandler.invoked);
+        assertFalse("Hover handler should NOT have been invoked", hoverEventHandler.invoked);
+    }
+
+    @Test
+    public void testMultipleHandlersOfSingleEventType() {
+        final EventBus eventBus = new EventBus();
+        final EventSource eventSource = new EventSource();
+        final TestEventHandler clickEventHandler = new TestEventHandler();
+        final TestEventHandler clickEventHandler2 = new TestEventHandler();
+        eventBus.addHandler(CLICK_EVENT_TYPE, clickEventHandler);
+        eventBus.addHandler(CLICK_EVENT_TYPE, clickEventHandler2);
+        final Event<TestEventHandler> clickEvent = new ClickTestEvent(eventSource);
+        assertFalse("Click handler 1 should NOT have been invoked", clickEventHandler.invoked);
+        assertFalse("Click handler 2 should NOT have been invoked", clickEventHandler2.invoked);
+        eventBus.fireEventFromSource(clickEvent, eventSource);
+        assertTrue("Click handler 1 should have been invoked", clickEventHandler.invoked);
+        assertTrue("Click handler 2 should have been invoked", clickEventHandler2.invoked);
+    }
+
+    @Test
+    public void testAddHandlerFromAnotherHandler() {
+        final EventBus eventBus = new EventBus();
+        final EventSource eventSource = new EventSource();
+        final TestEventHandler clickEventHandler2 = new TestEventHandler();
+        final TestEventHandler clickEventHandler = new TestEventHandler() {
+
+            @Override
+            void invoke() {
+                super.invoke();
+                eventBus.addHandler(CLICK_EVENT_TYPE, clickEventHandler2);
+            }
+        };
+        eventBus.addHandler(CLICK_EVENT_TYPE, clickEventHandler);
+        final Event<TestEventHandler> clickEvent = new ClickTestEvent(eventSource);
+        assertFalse("Click handler 1 should NOT have been invoked", clickEventHandler.invoked);
+        assertFalse("Click handler 2 should NOT have been invoked", clickEventHandler2.invoked);
+        eventBus.fireEventFromSource(clickEvent, eventSource);
+        assertTrue("Click handler 1 should have been invoked", clickEventHandler.invoked);
+        assertFalse("Click handler 2 should NOT have been invoked", clickEventHandler2.invoked);
+    }
+
+    @Test
+    public void testRemoveHandlerFromAnotherHandler() {
+        final EventBus eventBus = new EventBus();
+        final EventSource eventSource = new EventSource();
+        final TestEventHandler clickEventHandler2 = new TestEventHandler();
+        final TestEventHandler clickEventHandler = new TestEventHandler() {
+
+            @Override
+            void invoke() {
+                super.invoke();
+                eventBus.removeHandler(CLICK_EVENT_TYPE, clickEventHandler2);
+            }
+        };
+        eventBus.addHandler(CLICK_EVENT_TYPE, clickEventHandler);
+        eventBus.addHandler(CLICK_EVENT_TYPE, clickEventHandler2);
+        final Event<TestEventHandler> clickEvent = new ClickTestEvent(eventSource);
+        assertFalse("Click handler 1 should NOT have been invoked", clickEventHandler.invoked);
+        assertFalse("Click handler 2 should NOT have been invoked", clickEventHandler2.invoked);
+        eventBus.fireEventFromSource(clickEvent, eventSource);
+        assertTrue("Click handler 1 should have been invoked", clickEventHandler.invoked);
+        assertTrue("Click handler 2 should have been invoked", clickEventHandler2.invoked);
+    }
+
+    private static class TestEventHandler implements EventHandler {
+
+        private boolean invoked = false;
+
+        void invoke() {
+            invoked = true;
+        }
+    }
+
+    private static class TestBroadcastHandler implements BroadcastEventHandler {
+
+        private boolean invoked = false;
+
+        @Override
+        public void onEvent(final Event<?> event) {
+            invoked = true;
+        }
+    }
+
+    private static abstract class TestEvent extends Event<TestEventHandler> {
+
+        protected TestEvent(final Object source) {
+            super(source);
+        }
+
+        @Override
+        protected void dispatch(final TestEventHandler handler) {
+            handler.invoke();
+        }
+
+    }
+
+    private static class ClickTestEvent extends TestEvent {
+
+        protected ClickTestEvent(final Object source) {
+            super(source);
+        }
+
+        @Override
+        public Type getAssociatedType() {
+            return CLICK_EVENT_TYPE;
+        }
+
+    }
+
+    private static class HoverTestEvent extends TestEvent {
+
+        protected HoverTestEvent(final Object source) {
+            super(source);
+        }
+
+        @Override
+        public Type getAssociatedType() {
+            return HOVER_EVENT_TYPE;
+        }
+
+    }
+}


### PR DESCRIPTION
- Fix EventBus memory leak (caused by EventHandlers capturing widgets that are used as keys in a WeakHashMap, preventing all to be garbage collected).
- Refactor EventBus :
--> Add Class EventSource : Map of handlers per Event Type
--> 1 EventSource per PWidget
--> 1 global EventSource per EventBus
--> Remove Map of handlers per source per Event Type from EventBus.
--> Remove useless fields from EventBus
- Add EventBusTest